### PR TITLE
PLAT-38 - 0.1.7 to 0.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
   "name": "aho-corasick-node-rs",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Aho-Corasick Rust library Node.js bindings",
   "main": "lib/index.js",
   "author": "Vladimir Skvortsov <vlad@whereto.com>",
   "license": "MIT",
   "engines": {
     "node": ">=10.12.0"
+  },
+  "dependencies": {
+    "@mapbox/node-pre-gyp": "^1.0.11"
   },
   "os": [
     "darwin",


### PR DESCRIPTION
The dependencies `@mapbox/node-pre-gyp` were removed from 1.0.7 (1.0.6 - https://github.com/wherefortravel/aho-corasick-node-rs/commit/e68ce62bd71978fb3c9eb5fda9dc4b9ac330e0d4). This was published and forced the pulled repo to build locally. Adding this back in should allow the releases to be pulled instead of failing on a build error. 